### PR TITLE
fix: serialize native Error instances in renderCallbackResults

### DIFF
--- a/src/__tests__/behavioral/prompts/ResponseParserV2.test.ts
+++ b/src/__tests__/behavioral/prompts/ResponseParserV2.test.ts
@@ -391,8 +391,32 @@ export default class ResponseParserV2Test extends AbstractResponseParserTest {
         this.callbackStyle = callbackStyle
     }
 
+    @test()
+    protected async nativeCallbackErrorsSerializeWithMessageNotEmptyObject() {
+        this.setCallback('nativeErrorCb', {
+            cb: () => {
+                throw new TypeError('fetch failed — network unreachable')
+            },
+            useThisWhenever: 'you want to test native error serialization',
+        })
+
+        const results = await this.parse(
+            this.renderCallback({ name: 'nativeErrorCb' })
+        )
+
+        assert.doesInclude(
+            results.callbackResults ?? '',
+            'fetch failed — network unreachable',
+            'A native Error thrown from a callback must serialize its message, not produce an empty {} error object'
+        )
+    }
+
     private renderCallbackResults(options: Record<string, any>) {
-        return `@results ${JSON.stringify(options)}\n`
+        const serializable = { ...options }
+        if (serializable.error instanceof Error) {
+            serializable.error = { message: serializable.error.message }
+        }
+        return `@results ${JSON.stringify(serializable)}\n`
     }
 
     private renderCallback(options: Record<string, any>): string {

--- a/src/parsingResponses/ResponseParserV2.ts
+++ b/src/parsingResponses/ResponseParserV2.ts
@@ -123,7 +123,11 @@ export default class ResponseParserV2 implements ResponseParser {
         results?: LmmCallbackResponse | undefined
         error?: any
     }) {
-        return `@results ${JSON.stringify(callbackOptions)}\n`
+        const serializable = { ...callbackOptions }
+        if (serializable.error instanceof Error) {
+            serializable.error = { message: serializable.error.message }
+        }
+        return `@results ${JSON.stringify(serializable)}\n`
     }
 
     public getStateUpdateInstructions(): string {


### PR DESCRIPTION
## Summary

- `renderCallbackResults` used `JSON.stringify(callbackOptions)` directly. When a callback throws a native Error (TypeError from network failure, SyntaxError, etc.), the error field serializes as `{}` — giving the LLM empty, unusable error information.
- Fix: spread `callbackOptions` and convert any `Error` instance in the `error` field to `{ message: err.message }` before serializing.
- Adds a new behavioral test: a callback throwing `TypeError` must produce a readable message string, not `{}`.

## Root Cause

Native JS Error objects have no enumerable properties, so `JSON.stringify(new TypeError('...'))` → `{}`. This affects:
- Callback network errors (fetch TypeError)
- `@updateState` JSON parse errors (SyntaxError caught in the parse block)
- Any callback that throws a native Error

## Test

New test `nativeCallbackErrorsSerializeWithMessageNotEmptyObject` in `ResponseParserV2.test.ts` verifies the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)